### PR TITLE
default language to FR to fix an issue

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-   <setting id="language" type="enum" label="30101" values="DE|FR"/>
+   <setting id="language" type="enum" label="30101" values="DE|FR" default="1"/>
    <setting id="maxVideoQuality" type="enum" label="30106" values="480p|720p" default="1"/>
    <setting id="streamingType" type="enum" label="30108" values="HTTP|RTMP" default="0"/>
    <setting id="useThumbAsFanart" type="bool" label="30107" default="true"/>


### PR DESCRIPTION
The script fails if installed on a new system because there is no default language selected
